### PR TITLE
Ensure service worker script src is same as scope

### DIFF
--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -94,7 +94,7 @@ function wp_get_service_worker_url( $scope = WP_Service_Workers::SCOPE_FRONT ) {
 	if ( WP_Service_Workers::SCOPE_FRONT === $scope ) {
 		return add_query_arg(
 			array( WP_Service_Workers::QUERY_VAR => $scope ),
-			home_url( '/' )
+			home_url( '/', 'relative' )
 		);
 	}
 


### PR DESCRIPTION
Fixes #231.

When testing the WPGlobus plugin I found that when accessing the Spanish-language version of the site at `/es/` I was getting a service worker installed as:

```js
navigator.serviceWorker.register(
	'https://example.com/es/?wp_service_worker=1',
	{ scope: '/'}
).then( reg => { /* ... */ });
```

Note the inconsistency in the `scope` of `/` and the script src having a base URL of `/es/`. This resulted in an error:

> The path of the provided scope ('/') is not under the max scope allowed ('/es/'). Adjust the scope, move the Service Worker script, or use the Service-Worker-Allowed HTTP header to allow the scope.

The issue is that the WPGlobus plugin is apparently filtering the `home_url` differently based on the scheme being supplied to `home_url()`. So the quick fix is just to make sure that the `home_url()` used to obtain the script URL be made consistent with the URL used for the scope.

https://github.com/GoogleChromeLabs/pwa-wp/blob/af49d9a555bfee97e66b3307377897bde45e3fdb/wp-includes/service-workers.php#L142

https://github.com/GoogleChromeLabs/pwa-wp/blob/af49d9a555bfee97e66b3307377897bde45e3fdb/wp-includes/service-workers.php#L95-L98

The issue is fixed merely by changing the latter from `home_url( '/' )` to `home_url( '/', 'relative )`.