### PR TITLE
Include workbox version in library path to ensure cache busting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /phpcs.xml
 /.phpcs.xml
 *.zip
-/wp-includes/js/workbox/
+/wp-includes/js/workbox*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
 			},
 			install_workbox: {
 				command:
-					"if [ -e wp-includes/js/workbox* ]; then rm -r wp-includes/js/workbox*; fi; npx workbox copyLibraries wp-includes/js/ && mv wp-includes/js/workbox-v* wp-includes/js/workbox",
+					"if [ -e wp-includes/js/workbox* ]; then rm -r wp-includes/js/workbox*; fi; npx workbox copyLibraries wp-includes/js/",
 			},
 			create_build_zip: {
 				command:
@@ -97,7 +97,7 @@ module.exports = function (grunt) {
 						file
 					);
 				});
-			paths.push("wp-includes/js/workbox/*");
+			paths.push("wp-includes/js/workbox*/**");
 
 			grunt.task.run("clean");
 			grunt.task.run("readme");
@@ -124,6 +124,13 @@ module.exports = function (grunt) {
 										"$1" + version
 									);
 								}
+
+								const workboxVersion = grunt.file.readJSON("package.json")
+									.devDependencies["workbox-cli"];
+								content = content.replace(
+									/define\(.+?PWA_WORKBOX_VERSION.+/,
+									`define( 'PWA_WORKBOX_VERSION', '${workboxVersion}' );`
+								);
 							}
 							return content;
 						},

--- a/pwa.php
+++ b/pwa.php
@@ -20,6 +20,7 @@
 define( 'PWA_VERSION', '0.4.0' );
 define( 'PWA_PLUGIN_FILE', __FILE__ );
 define( 'PWA_PLUGIN_DIR', dirname( __FILE__ ) );
+define( 'PWA_WORKBOX_VERSION', json_decode( file_get_contents( PWA_PLUGIN_DIR . '/package.json' ), true )['devDependencies']['workbox-cli'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Replaced with version literal build.
 define( 'PWA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 /**
@@ -95,7 +96,7 @@ function _pwa_print_build_needed_notice() {
 	</div>
 	<?php
 }
-if ( ! file_exists( __DIR__ . '/wp-includes/js/workbox/' ) || ! file_exists( __DIR__ . '/wp-includes/js/workbox/workbox-sw.js' ) ) {
+if ( ! file_exists( __DIR__ . '/wp-includes/js/workbox-v' . PWA_WORKBOX_VERSION ) || ! file_exists( __DIR__ . '/wp-includes/js/workbox-v' . PWA_WORKBOX_VERSION . '/workbox-sw.js' ) ) {
 	add_action( 'admin_notices', '_pwa_print_build_needed_notice' );
 	return;
 }

--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -52,7 +52,7 @@ class WP_Service_Worker_Configuration_Component implements WP_Service_Worker_Com
 	 */
 	public function get_script() {
 		$current_scope = wp_service_workers()->get_current_scope();
-		$workbox_dir   = 'wp-includes/js/workbox/';
+		$workbox_dir   = sprintf( 'wp-includes/js/workbox-v%s/', PWA_WORKBOX_VERSION );
 
 		$script = '';
 		if ( SCRIPT_DEBUG ) {


### PR DESCRIPTION
Fixes issue where an plugin update can result in cached Workbox library files from an older version are used and potentially causing a JS error.