### PR TITLE
Prevent attempting to precache empty URLs which causes SW install failure

### DIFF
--- a/tests/components/test-class-wp-service-worker-precaching-routes.php
+++ b/tests/components/test-class-wp-service-worker-precaching-routes.php
@@ -83,4 +83,17 @@ class Test_WP_Service_Worker_Precaching_Routes extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test registering a route that is empty.
+	 *
+	 * @covers WP_Service_Worker_Precaching_Routes::register()
+	 */
+	public function test_register_empty_url() {
+		$this->setExpectedIncorrectUsage( 'WP_Service_Worker_Precaching_Routes::register' );
+		$this->instance->register( '' );
+
+		$routes = $this->instance->get_all();
+		$this->assertEmpty( $routes );
+	}
 }

--- a/wp-includes/components/class-wp-service-worker-precaching-routes.php
+++ b/wp-includes/components/class-wp-service-worker-precaching-routes.php
@@ -33,6 +33,11 @@ class WP_Service_Worker_Precaching_Routes implements WP_Service_Worker_Registry 
 	 * }
 	 */
 	public function register( $url, $args = array() ) {
+		if ( empty( $url ) || false === wp_parse_url( $url ) ) {
+			_doing_it_wrong( __METHOD__, esc_html__( 'Invalid URL provided for precaching.', 'pwa' ), '0.4.1' );
+			return;
+		}
+
 		if ( ! is_array( $args ) ) {
 			$args = array(
 				'revision' => $args,


### PR DESCRIPTION
Fixes #270.

At the moment when attempting to precache an empty URL such as via:

```php
add_action( 'wp_front_service_worker', function ( WP_Service_Worker_Scripts $service_worker ) {
	$service_worker->precaching_routes()->register( '' );
} );
```

The result is the service worker failing to install at all.

For this reason, this PR emits a `_doing_it_wrong` if the `$url` is empty or cannot be parsed. This allows the service worker to still be installed, while the incorrect usage will appear in the error log.

Aside: It may be better to also emit the incorrect usage via `console.warn()` so that the issue is more easily seen.