### PR TITLE
Prevent service worker from varying by authentication state (and prevent auto-reloading)

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -11,6 +11,7 @@
 		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>./node_modules/</exclude-pattern>
 	<exclude-pattern>./vendor/</exclude-pattern>
+	<exclude-pattern>./build/</exclude-pattern>
 
 	<!-- How to scan -->
 	<arg value="sp"/> <!-- Show sniff and progress -->

--- a/pwa.php
+++ b/pwa.php
@@ -223,6 +223,9 @@ require_once PWA_PLUGIN_DIR . '/wp-includes/components/class-wp-service-worker-c
 /** WordPress Service Worker Functions */
 require_once PWA_PLUGIN_DIR . '/wp-includes/service-workers.php';
 
+/** WordPress Service Worker Deprecated */
+require_once PWA_PLUGIN_DIR . '/wp-includes/deprecated.php';
+
 /** Amend default filters */
 require_once PWA_PLUGIN_DIR . '/wp-includes/default-filters.php';
 

--- a/tests/test-class-wp-service-workers.php
+++ b/tests/test-class-wp-service-workers.php
@@ -63,9 +63,12 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 		add_action( 'wp_front_service_worker', array( $this, 'register_foo_sw' ) );
 		add_action( 'wp_admin_service_worker', array( $this, 'register_foo_sw' ) );
 
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'subscriber' ) ) );
 		ob_start();
 		wp_service_workers()->serve_request();
 		$output = ob_get_clean();
+
+		$this->assertSame( 0, get_current_user_id() );
 		$this->assertContains( $this->return_foo_sw(), $output );
 		$this->assertContains( $this->return_bar_sw(), $output );
 		$this->assertNotContains( $this->return_baz_sw(), $output );
@@ -86,11 +89,13 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 		add_action( 'wp_front_service_worker', array( $this, 'register_foo_sw' ) );
 		add_action( 'wp_admin_service_worker', array( $this, 'register_foo_sw' ) );
 
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 		ob_start();
 		set_current_screen( 'admin-ajax' );
 		wp_service_workers()->serve_request();
 		$output = ob_get_clean();
 
+		$this->assertSame( 0, get_current_user_id() );
 		$this->assertContains( $this->return_foo_sw(), $output );
 		$this->assertNotContains( $this->return_bar_sw(), $output );
 		$this->assertContains( $this->return_baz_sw(), $output );

--- a/tests/test-general-template.php
+++ b/tests/test-general-template.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Tests for general-template.php.
+ *
+ * @package PWA
+ */
+
+/**
+ * Tests for general-template.php.
+ */
+class Test_General_Template extends WP_UnitTestCase {
+
+	/**
+	 * Get data for testing wp_unauthenticate_error_template_requests().
+	 *
+	 * @return array Data.
+	 */
+	public function get_error_template_request_data() {
+		return array(
+			'homepage' => array(
+				home_url( '/' ),
+				true,
+				static function() {
+					return ! is_500() && ! is_offline();
+				},
+			),
+			'500'      => array(
+				home_url( '/?wp_error_template=500' ),
+				false,
+				static function() {
+					return is_500() && ! is_offline();
+				},
+			),
+			'offline'  => array(
+				home_url( '/?wp_error_template=offline' ),
+				false,
+				static function() {
+					return ! is_500() && is_offline();
+				},
+			),
+		);
+	}
+
+	/**
+	 * Test wp_unauthenticate_error_template_requests.
+	 *
+	 * @dataProvider get_error_template_request_data
+	 * @covers ::wp_unauthenticate_error_template_requests()
+	 * @covers ::is_500()
+	 * @covers ::is_offline()
+	 * @covers ::pwa_add_public_query_vars()
+	 *
+	 * @param string   $request_url        URL.
+	 * @param bool     $authenticated      Authentication expected.
+	 * @param callable $check_conditionals Check conditionals.
+	 */
+	public function test_wp_unauthenticate_error_template_requests( $request_url, $authenticated, $check_conditionals ) {
+		$this->assertEquals( 10, has_action( 'parse_query', 'wp_unauthenticate_error_template_requests' ) );
+		$initial_parse_query_count = did_action( 'parse_query' );
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $user_id );
+		$this->go_to( $request_url );
+
+		$this->assertEquals( $initial_parse_query_count + 1, did_action( 'parse_query' ) );
+		$this->assertTrue( $check_conditionals() );
+
+		if ( $authenticated ) {
+			$this->assertTrue( is_user_logged_in() );
+			$this->assertEquals( $user_id, get_current_user_id() );
+		} else {
+			$this->assertFalse( is_user_logged_in() );
+			$this->assertEquals( 0, get_current_user_id() );
+		}
+	}
+}

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -91,6 +91,10 @@ class WP_Service_Workers implements WP_Service_Worker_Registry_Aware {
 	 * @see wp_service_worker_loaded()
 	 */
 	public function serve_request() {
+		// Clear the currently-authenticated user to ensure that the service worker doesn't vary between users.
+		// @todo Would it be better to use the determine_current_user filter for this?
+		wp_set_current_user( 0 );
+
 		// See wp_debug_mode() for how this is also done for REST API responses.
 		@ini_set( 'display_errors', 0 ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_ini_set, WordPress.PHP.IniSet.display_errors_Blacklisted
 

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -91,8 +91,14 @@ class WP_Service_Workers implements WP_Service_Worker_Registry_Aware {
 	 * @see wp_service_worker_loaded()
 	 */
 	public function serve_request() {
-		// Clear the currently-authenticated user to ensure that the service worker doesn't vary between users.
-		// @todo Would it be better to use the determine_current_user filter for this?
+		/*
+		 * Clear the currently-authenticated user to ensure that the service worker doesn't vary between users.
+		 * Note that clearing the authenticated user in this way is in keeping with REST API requests wherein the
+		 * WP_REST_Server::serve_request() method calls WP_REST_Server::check_authentication() which in turn applies
+		 * the rest_authentication_errors filter which runs rest_cookie_check_errors() which is then responsible for
+		 * calling wp_set_current_user( 0 ) if it was previously-determined a user was logged-in with the required
+		 * nonce cookie set when wp_validate_auth_cookie() triggers one of the auth_cookie_* actions.
+		 */
 		wp_set_current_user( 0 );
 
 		// See wp_debug_mode() for how this is also done for REST API responses.

--- a/wp-includes/class-wp.php
+++ b/wp-includes/class-wp.php
@@ -11,14 +11,15 @@
  *
  * Upon core merge the query vars here could be added straight to `WP::$public_query_vars`.
  *
- * @global WP $wp
+ * @param string[] $query_vars Query vars.
+ * @return string[] Query vars.
  */
-function pwa_add_error_template_query_var() {
-	global $wp;
-	$wp->add_query_var( 'wp_error_template' );
-	$wp->add_query_var( WP_Service_Workers::QUERY_VAR );
+function pwa_add_public_query_vars( $query_vars ) {
+	$query_vars[] = 'wp_error_template';
+	$query_vars[] = WP_Service_Workers::QUERY_VAR;
+	return $query_vars;
 }
-add_action( 'init', 'pwa_add_error_template_query_var' );
+add_filter( 'query_vars', 'pwa_add_public_query_vars' );
 
 /**
  * Prevent handling an offline template request as a 404 when there are no posts published.

--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -102,15 +102,16 @@ class WP_Service_Worker_Configuration_Component implements WP_Service_Worker_Com
 		 * within scope will be controlled by a service worker immediately after that service worker activates.
 		 * Without enabling it, they won't be controlled until the next navigation.
 		 *
-		 * For optioning in for .clientsClaim(), you could do:
+		 * For opting-out of client claiming, the following code may be used:
 		 *
-		 *     add_filter( 'wp_service_worker_clients_claim', '__return_true' );
+		 *     add_filter( 'wp_service_worker_clients_claim', '__return_false' );
 		 *
 		 * @since 0.2
+		 * @since 0.4.1 Enabled by default.
 		 *
-		 * @param bool $clients_claim Whether to run clientsClaim() after skipWaiting().
+		 * @param bool $clients_claim Whether to run clientsClaim() after skipWaiting(). Defaults to true.
 		 */
-		$clients_claim = apply_filters( 'wp_service_worker_clients_claim', false );
+		$clients_claim = apply_filters( 'wp_service_worker_clients_claim', true );
 
 		if ( true === $skip_waiting ) {
 			$script .= "workbox.core.skipWaiting();\n";

--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -68,9 +68,6 @@ class WP_Service_Worker_Navigation_Routing_Component implements WP_Service_Worke
 			$revision .= sprintf( ';%s=%s', $stylesheet, wp_get_theme( $stylesheet )->version );
 		}
 
-		// Ensure the user-specific offline/500 pages are precached, and that they update when user logs out or switches to another user.
-		$revision .= sprintf( ';user=%d', get_current_user_id() );
-
 		if ( ! is_admin() ) {
 			// Note that themes will need to vary the revision further by whatever is contained in the app shell.
 			$revision .= ';options=' . md5(

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -21,9 +21,3 @@ add_action( 'wp_head', 'wp_add_error_template_no_robots' );
 add_action( 'error_head', 'wp_add_error_template_no_robots' );
 
 add_action( 'admin_init', 'wp_disable_script_concatenation' );
-
-// Service Worker Updating.
-add_action( 'admin_bar_menu', 'wp_service_worker_update_node', 999 );
-
-add_action( 'wp_enqueue_scripts', 'wp_service_worker_styles', 11 );
-add_action( 'admin_enqueue_scripts', 'wp_service_worker_styles', 11 );

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -15,7 +15,7 @@ foreach ( array( 'wp_print_footer_scripts', 'admin_print_scripts', 'customize_co
 add_action( 'parse_query', 'wp_service_worker_loaded' );
 add_action( 'wp_ajax_wp_service_worker', 'wp_ajax_wp_service_worker' );
 add_action( 'wp_ajax_nopriv_wp_service_worker', 'wp_ajax_wp_service_worker' );
-add_action( 'parse_query', 'wp_hide_admin_bar_offline' );
+add_action( 'parse_query', 'wp_unset_current_user_error_template' );
 
 add_action( 'wp_head', 'wp_add_error_template_no_robots' );
 add_action( 'error_head', 'wp_add_error_template_no_robots' );

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -15,7 +15,7 @@ foreach ( array( 'wp_print_footer_scripts', 'admin_print_scripts', 'customize_co
 add_action( 'parse_query', 'wp_service_worker_loaded' );
 add_action( 'wp_ajax_wp_service_worker', 'wp_ajax_wp_service_worker' );
 add_action( 'wp_ajax_nopriv_wp_service_worker', 'wp_ajax_wp_service_worker' );
-add_action( 'parse_query', 'wp_unset_current_user_error_template' );
+add_action( 'parse_query', 'wp_unauthenticate_error_template_requests' );
 
 add_action( 'wp_head', 'wp_add_error_template_no_robots' );
 add_action( 'error_head', 'wp_add_error_template_no_robots' );

--- a/wp-includes/deprecated.php
+++ b/wp-includes/deprecated.php
@@ -2,7 +2,7 @@
 /**
  * Service Worker deprecated.
  *
- * @since 0.4.1
+ * @since 0.5
  *
  * @package PWA
  */
@@ -12,10 +12,10 @@
  *
  * @deprecated No longer used.
  * @since 0.2
- * @since 0.4.1 Deprecated.
+ * @since 0.5 Deprecated.
  */
 function wp_service_worker_styles() {
-	_deprecated_function( __FUNCTION__, '0.4.1' );
+	_deprecated_function( __FUNCTION__, '0.5' );
 }
 
 /**
@@ -23,10 +23,10 @@ function wp_service_worker_styles() {
  *
  * @deprecated No longer used.
  * @since 0.2
- * @since 0.4.1 Deprecated.
+ * @since 0.5 Deprecated.
  */
 function wp_service_worker_update_node() {
-	_deprecated_function( __FUNCTION__, '0.4.1' );
+	_deprecated_function( __FUNCTION__, '0.5' );
 }
 
 /**
@@ -34,8 +34,8 @@ function wp_service_worker_update_node() {
  *
  * @deprecated No longer used.
  * @since 0.2
- * @since 0.4.1 Deprecated.
+ * @since 0.5 Deprecated.
  */
 function wp_hide_admin_bar_offline() {
-	_deprecated_function( __FUNCTION__, '0.4.1' );
+	_deprecated_function( __FUNCTION__, '0.5' );
 }

--- a/wp-includes/deprecated.php
+++ b/wp-includes/deprecated.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Service Worker deprecated.
+ *
+ * @since 0.4.1
+ *
+ * @package PWA
+ */
+
+/**
+ * Service worker styles.
+ *
+ * @deprecated No longer used.
+ * @since 0.2
+ * @since 0.4.1 Deprecated.
+ */
+function wp_service_worker_styles() {
+	_deprecated_function( __FUNCTION__, '0.4.1' );
+}
+
+/**
+ * Add Service Worker update notification to admin bar.
+ *
+ * @deprecated No longer used.
+ * @since 0.2
+ * @since 0.4.1 Deprecated.
+ */
+function wp_service_worker_update_node() {
+	_deprecated_function( __FUNCTION__, '0.4.1' );
+}

--- a/wp-includes/deprecated.php
+++ b/wp-includes/deprecated.php
@@ -28,3 +28,14 @@ function wp_service_worker_styles() {
 function wp_service_worker_update_node() {
 	_deprecated_function( __FUNCTION__, '0.4.1' );
 }
+
+/**
+ * Hide the admin bar if serving the offline template.
+ *
+ * @deprecated No longer used.
+ * @since 0.2
+ * @since 0.4.1 Deprecated.
+ */
+function wp_hide_admin_bar_offline() {
+	_deprecated_function( __FUNCTION__, '0.4.1' );
+}

--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -101,13 +101,16 @@ function wp_add_error_template_no_robots() {
 }
 
 /**
- * Hide the admin bar if serving the offline template.
+ * Ensure current user is unset when serving an error page (either offline or server error).
  *
- * @since 0.2
+ * This is important so that what the service worker initially precaches for the user when first accessing the site
+ * will persist even after they have authenticated.
+ *
+ * @since 0.4.1
  */
-function wp_hide_admin_bar_offline() {
-	if ( is_offline() ) {
-		show_admin_bar( false );
+function wp_unset_current_user_error_template() {
+	if ( is_offline() || is_500() ) {
+		wp_set_current_user( 0 );
 	}
 }
 

--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -108,7 +108,7 @@ function wp_add_error_template_no_robots() {
  *
  * @since 0.5
  */
-function wp_unset_current_user_error_template() {
+function wp_unauthenticate_error_template_requests() {
 	if ( is_offline() || is_500() ) {
 		wp_set_current_user( 0 );
 	}

--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -106,7 +106,7 @@ function wp_add_error_template_no_robots() {
  * This is important so that what the service worker initially precaches for the user when first accessing the site
  * will persist even after they have authenticated.
  *
- * @since 0.4.1
+ * @since 0.5
  */
 function wp_unset_current_user_error_template() {
 	if ( is_offline() || is_500() ) {

--- a/wp-includes/js/service-worker.js
+++ b/wp-includes/js/service-worker.js
@@ -10,7 +10,11 @@ if (!self.wp) {
 
 wp.serviceWorker = workbox;
 
-// Skip the waiting phase for the Service Worker.
+/*
+ * Skip the waiting phase for the Service Worker when a message with a 'skipWaiting' action is sent from a client.
+ * Note that this message is not currently being sent in the codebase, but the logic remains here to provide a
+ * mechanism for clients to skip waiting if they want to.
+ */
 self.addEventListener('message', function (event) {
 	if ('skipWaiting' === event.data.action) {
 		self.skipWaiting();

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -157,7 +157,6 @@ function wp_print_service_workers() {
 			window.addEventListener( 'load', function() {
 				<?php foreach ( $scopes as $name => $scope ) : ?>
 					{
-						let updatedSw;
 						navigator.serviceWorker.register(
 							<?php echo wp_json_encode( wp_get_service_worker_url( $name ) ); ?>,
 							<?php echo wp_json_encode( compact( 'scope' ) ); ?>
@@ -165,38 +164,7 @@ function wp_print_service_workers() {
 							<?php if ( WP_Service_Workers::SCOPE_ADMIN === $name ) : ?>
 								document.cookie = <?php echo wp_json_encode( sprintf( 'wordpress_sw_installed=1; path=%s; expires=Fri, 31 Dec 9999 23:59:59 GMT; secure; samesite=strict', $scope ) ); ?>;
 							<?php endif; ?>
-							<?php if ( ! wp_service_worker_skip_waiting() ) : ?>
-								reg.addEventListener( 'updatefound', () => {
-									if ( ! reg.installing ) {
-										return;
-									}
-									updatedSw = reg.installing;
-
-									/* If new service worker is available, show notification. */
-									updatedSw.addEventListener( 'statechange', () => {
-										if ( 'installed' === updatedSw.state && navigator.serviceWorker.controller ) {
-											const notification = document.getElementById( 'wp-admin-bar-pwa-sw-update-notice' );
-											if ( notification ) {
-												notification.style.display = 'block';
-											}
-										}
-									} );
-								} );
-							<?php endif; ?>
 						} );
-
-						<?php if ( is_admin_bar_showing() && ! wp_service_worker_skip_waiting() ) : ?>
-							/* Post message to Service Worker for skipping the waiting phase. */
-							const reloadBtn = document.getElementById( 'wp-admin-bar-pwa-sw-update-notice' );
-							if ( reloadBtn ) {
-								reloadBtn.addEventListener( 'click', ( event ) => {
-									event.preventDefault();
-									if ( updatedSw ) {
-										updatedSw.postMessage( { action: 'skipWaiting' } );
-									}
-								} );
-							}
-						<?php endif; ?>
 					}
 				<?php endforeach; ?>
 			} );
@@ -267,35 +235,6 @@ function wp_disable_script_concatenation() {
 		$concatenate_scripts = rest_sanitize_boolean( $_GET['wp_concatenate_scripts'] );
 	}
 	// phpcs:enable
-}
-
-/**
- * Service worker styles.
- *
- * @since 0.2
- */
-function wp_service_worker_styles() {
-	wp_add_inline_style( 'admin-bar', '#wp-admin-bar-pwa-sw-update-notice { display:none }' );
-}
-
-/**
- * Add Service Worker update notification to admin bar.
- *
- * @since 0.2
- *
- * @param object $wp_admin_bar WP Admin Bar.
- */
-function wp_service_worker_update_node( $wp_admin_bar ) {
-	if ( wp_service_worker_skip_waiting() ) {
-		return;
-	}
-	$wp_admin_bar->add_node(
-		array(
-			'id'    => 'pwa-sw-update-notice',
-			'title' => __( 'Update to a new version of this site!', 'pwa' ),
-			'href'  => '#',
-		)
-	);
 }
 
 /**

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -199,14 +199,6 @@ function wp_print_service_workers() {
 						<?php endif; ?>
 					}
 				<?php endforeach; ?>
-
-				let refreshedPage = false;
-				navigator.serviceWorker.addEventListener( 'controllerchange', () => {
-					if ( ! refreshedPage ) {
-						refreshedPage = true;
-						window.location.reload();
-					}
-				} );
 			} );
 		}
 	</script>

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -185,7 +185,7 @@ function wp_print_service_workers() {
 function wp_service_worker_loaded( WP_Query $query ) {
 	if ( $query->is_main_query() && $query->get( WP_Service_Workers::QUERY_VAR ) ) {
 		wp_service_workers()->serve_request();
-		exit;
+		die();
 	}
 }
 
@@ -199,7 +199,7 @@ function wp_service_worker_loaded( WP_Query $query ) {
  */
 function wp_ajax_wp_service_worker() {
 	wp_service_workers()->serve_request();
-	exit;
+	die();
 }
 
 /**


### PR DESCRIPTION
This PR does a few things to fix some long-standing annoyances.

1. When an updated service worker is activated, the window will not automatically reload.
2. As soon as a service worker is installed, clients are now claimed by default; this makes sense to do since WordPress pages are not (normally) single-page-applications. In other words, a page accessed without a service worker is the same as a page served with a service worker (it's just the latter may be served from cache). If `clients.claim()` is not desired, it can be disabled via `add_filter( 'wp_service_worker_clients_claim', '__return_false' )`. This seems the best default for at least the 80% use case.
3. Eliminate the “update site” link which was (rarely) shown. It was only shown when skip-waiting was disabled and if the admin bar was showing. Now skip-waiting is enabled and no reloading is being done, there is no need for this additional button. If a site wants to disable skip-waiting and add such a button, they can still do so. Again, it's removed since it's not deemed part in the 80% use case.
4. Prevent the error templates for offline and 500 from being served with logged-in user state. Site owners should expect that that user-specific information should not be displayed on this page. This prevents the need for the service worker to update once logging-in or logging-out. 
5. In the same way, the service workers are also served with the user authentication being cleared to avoid serving user-specific information in the service worker. This also guards against the service worker varying by authentication state. This is somewhat similar to how the REST API behaves. Nevertheless, this may end up being an undesirable and we'll need to watch this for use cases. It could be useful to serve some auth key (e.g. REST API nonce) in the service worker, but this would end up being a pain as well once the key expires.

Fixes #205.
Fixes #166.
Fixes #202.
Fixes #249.
Fixes #223.